### PR TITLE
Changing example to include valid runtime_assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,8 @@ metadata:
   namespace: default
 spec:
   command: system-profile-linux
-  runtime_assets: system-profile-linux-amd64
+  runtime_assets: 
+  - system-profile-linux-amd64
   subscriptions:
   - linux
   interval: 10


### PR DESCRIPTION
Copy/pasta from this example in the readme results in an invalid yml file. Minor change here to ensure it's valid.